### PR TITLE
allow numbers it cut vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### `0.7.3`:
+* changed valid cut variable regex from  `[A-Za-z_]` to `[A-Za-z_0-9]` as alpha _numerics_ were the intended format
+
 #### `0.7.2`:
 * migrated `cargho` back to `argh` since new version was released
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.7.2"
+version = "0.7.3"
 description = "A contract testing tool built in Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.6.1"
+version = "0.6.2"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/filmreel/src/cut.rs
+++ b/filmreel/src/cut.rs
@@ -16,7 +16,7 @@ pub struct Register {
 }
 
 const VAR_NAME_ERR: &str = "Only alphanumeric characters, dashes, and underscores are permitted \
-                            in Cut Variable names => [A-Za-z_]";
+                            in Cut Variable names => [A-Za-z_0-9]";
 
 /// The Register's map of [Cut Variables]
 /// (https://github.com/mkatychev/filmReel/blob/master/cut.md#cut-variable)
@@ -123,10 +123,10 @@ impl Register {
         lazy_static! {
             static ref VAR_MATCH: Regex = Regex::new(
                 r"(?x)
-                (?P<esc_char>\\)?   # escape character
-                (?P<leading_b>\$\{) # leading brace
-                (?P<cut_var>[A-za-z_0-9]+) # Cut Variable
-                (?P<trailing_b>})?  # trailing brace
+                (?P<esc_char>\\)?          # escape character
+                (?P<leading_b>\$\{)        # leading brace
+                (?P<cut_var>[A-Za-z_0-9]+) # Cut Variable
+                (?P<trailing_b>})?         # trailing brace
                 "
             )
             .unwrap();
@@ -276,7 +276,7 @@ impl Register {
     pub fn write_operation(&mut self, key: &str, val: Value) -> Result<Option<Value>, FrError> {
         lazy_static! {
             // Permit only alphachars dashes and underscores for variable names
-            static ref KEY_CHECK: Regex = Regex::new(r"^[A-Za-z_]+$").unwrap();
+            static ref KEY_CHECK: Regex = Regex::new(r"^[A-Za-z_0-9]+$").unwrap();
         }
         if !KEY_CHECK.is_match(key) {
             return Err(FrError::FrameParsef(VAR_NAME_ERR, key.to_string()));
@@ -288,7 +288,7 @@ impl Register {
     pub fn flush_ignored(&mut self) {
         lazy_static! {
         // if key value consists of only lowercase letters and underscores
-            static ref KEY_IGNORE: Regex = Regex::new(r"^[a-z_]+$").unwrap();
+            static ref KEY_IGNORE: Regex = Regex::new(r"^[a-z_0-9]+$").unwrap();
         }
         let mut remove: Vec<String> = vec![];
         for (k, _) in self.vars.iter() {


### PR DESCRIPTION
* changed valid cut variable regex from  `[A-Za-z_]` to `[A-Za-z_0-9]` as alpha _numerics_ were the intended format
