### PR TITLE
support multiple headers in grpc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,8 @@ jobs:
         run: cargo run -- vrecord ./test_data/post.vr.json
       - name: httpbin vrecord alt
         run: cargo run -- vrecord ./test_data/alt_post.vr.json
+      - name: grpcbin headers
+        run: cargo run -- record ./test_data grpc
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: install grpcurl
-        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz --directory=/usr/bin
+        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz --directory=/usr/local/bin
       - name: httpbin post
         run: cargo run -- record ./test_data post
       - name: httpbin take

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: install grpcurl
-        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz --directory=/usr/local/bin
+        run: |
+          sudo curl -sL https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz | sudo tar xvz -C /usr/local/bin/
+          sudo chmod +x /usr/local/bin/grpcurl
       - name: httpbin post
         run: cargo run -- record ./test_data post
       - name: httpbin take

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: install grpcurl
-        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz
+        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz --directory=/usr/bin
       - name: httpbin post
         run: cargo run -- record ./test_data post
       - name: httpbin take

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: install grpcurl
+        run: wget -c https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz -O - | tar -xz
       - name: httpbin post
         run: cargo run -- record ./test_data post
       - name: httpbin take

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -44,7 +44,6 @@ pub fn request<'a>(prm: Params, req: Request) -> Result<Response<'a>, Error> {
         ));
     }
 
-    // let mut headers: Vec<String> = Vec::new();
     if let Some(h) = &prm.header {
         if crate::guess_json_obj(h) {
             let map: HashMap<String, String> = serde_json::from_str(&h)?;
@@ -57,12 +56,6 @@ pub fn request<'a>(prm: Params, req: Request) -> Result<Response<'a>, Error> {
             flags.push(h.replace("\"", "").into());
         }
     };
-
-    // let headers2: Vec<&String> = headers.iter().map(|s| s).collect();
-    // for h in headers {
-    //     flags.push(OsString::from("-H"));
-    //     flags.push(OsString::from(h));
-    // }
 
     let req_cmd = Command::new("grpcurl")
         .args(flags)

--- a/test_data/grpc.01s.json_headers.fr.json
+++ b/test_data/grpc.01s.json_headers.fr.json
@@ -1,0 +1,38 @@
+{
+  "cut": {
+    "from": [
+      "ADDRESS"
+    ]
+  },
+  "protocol": "gRPC",
+  "request": {
+    "uri": "grpcbin.GRPCBin/HeadersUnary",
+    "entrypoint": "${ADDRESS}",
+    "header": {
+      "Header1": "header 1",
+      "Header2": "header 2"
+    }
+  },
+  "response": {
+    "validation": {
+      "'response'.'body'.'Metadata'": {
+        "partial": true
+      }
+    },
+    "body": {
+      "Metadata": {
+        "header1": {
+          "values": [
+            "header 1"
+          ]
+        },
+        "header2": {
+          "values": [
+            "header 2"
+          ]
+        }
+      }
+    },
+    "status": 0
+  }
+}

--- a/test_data/grpc.02s.string_header.fr.json
+++ b/test_data/grpc.02s.string_header.fr.json
@@ -1,0 +1,30 @@
+{
+  "cut": {
+    "from": [
+      "ADDRESS"
+    ]
+  },
+  "protocol": "gRPC",
+  "request": {
+    "uri": "grpcbin.GRPCBin/HeadersUnary",
+    "entrypoint": "${ADDRESS}",
+    "header": "Header1: header 1"
+  },
+  "response": {
+    "validation": {
+      "'response'.'body'.'Metadata'": {
+        "partial": true
+      }
+    },
+    "body": {
+      "Metadata": {
+        "header1": {
+          "values": [
+            "header 1"
+          ]
+        }
+      }
+    },
+    "status": 0
+  }
+}

--- a/test_data/grpc.cut.json
+++ b/test_data/grpc.cut.json
@@ -1,0 +1,3 @@
+{
+  "ADDRESS": "grpcb.in:9000"
+}

--- a/test_data/grpc.vr.json
+++ b/test_data/grpc.vr.json
@@ -1,0 +1,11 @@
+{
+  "name": "grpc_vreel",
+  "path": "./test_data",
+  "frames": [
+    "grpc.01s.multiple_headers.fr.json",
+    "grpc.02s.string_header.fr.json"
+  ],
+  "cut": {
+    "ADDRESS": "grpcb.in:9001"
+  }
+}

--- a/test_data/post.04s.multiple_headers.fr.json
+++ b/test_data/post.04s.multiple_headers.fr.json
@@ -1,0 +1,34 @@
+{
+  "cut": {
+    "from": [
+      "ADDRESS",
+      "URI_METHOD"
+    ]
+  },
+  "protocol": "HTTP",
+  "request": {
+    "uri": "${URI_METHOD} /post",
+    "entrypoint": "${ADDRESS}",
+    "header": {
+      "Header1": "header 1",
+      "Header2": "header 2"
+    }
+  },
+  "response": {
+    "validation": {
+      "'response'.'body'": {
+        "partial": true
+      },
+      "'response'.'body'.'headers'": {
+        "partial": true
+      }
+    },
+    "body": {
+      "headers": {
+          "Header1": "header 1",
+          "Header2": "header 2"
+        }
+    },
+    "status": 200
+  }
+}

--- a/test_data/post.vr.json
+++ b/test_data/post.vr.json
@@ -4,7 +4,8 @@
   "frames": [
     "post.01s.body.fr.json",
     "post.03s.delay.fr.json",
-    "post.02s.no_content.fr.json"
+    "post.02s.no_content.fr.json",
+    "post.04s.multiple_headers.fr.json"
   ],
   "cut": {
     "URI_METHOD": "POST",


### PR DESCRIPTION
This allows grpc commands to include multiple headers, while leaving the old single header string functionality.